### PR TITLE
fix: Resolve TypeScript type error in useAuth hook

### DIFF
--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -145,8 +145,10 @@ export function useAuth(): AuthState {
                         console.log('useAuth: Token refreshed for same user, profile retained.');
                         setLoading(false); // No need to re-fetch if profile for this user is already loaded
                     }
-                } else if (event !== 'SIGNED_OUT' && !newSession?.user) {
-                    // Session became null unexpectedly
+                } else if (!newSession?.user) {
+                    // If event is not 'SIGNED_OUT' and session is null, this block will be reached.
+                    // This covers cases where session becomes null without an explicit 'SIGNED_OUT' event.
+                    console.log('useAuth: Session is null and event is not SIGNED_OUT. Event:', event);
                     setProfile(null);
                     setRole(null);
                     setStaffBranchId(null);


### PR DESCRIPTION
Simplified a redundant condition in the `onAuthStateChange` handler within `hooks/use-auth.ts`. The `event !== 'SIGNED_OUT'` check was causing a type error because it was guaranteed to be true at that point in the logic. The condition now correctly focuses on `!newSession?.user` to handle unexpected null sessions.