### PR TITLE
URL'lerde şube kimliği yerine şube adı kullanıldı.

### DIFF
--- a/app/admin/branches/page.tsx
+++ b/app/admin/branches/page.tsx
@@ -779,7 +779,7 @@ export default function AdminBranchesPage() {
 															className="text-xs"
 															onClick={() =>
 																router.push(
-																	`/admin/branch-financials/${branch.id}`
+																	`/admin/branch-financials/${encodeURIComponent(branch.name)}`
 																)
 															}
 														>

--- a/app/api/branch/[id]/route.ts
+++ b/app/api/branch/[id]/route.ts
@@ -1,10 +1,30 @@
-// app/api/branch/[id]/route.ts
+// app/api/branch/[branchName]/route.ts // Dosya adını yansıtacak şekilde yorumu güncelle
 import { createClient } from '@/utils/supabase/client';
 import { NextResponse } from "next/server";
 
+// Helper function to get branch ID from branch name
+async function getBranchIdFromName(branchName: string) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('branches')
+    .select('id')
+    .eq('name', decodeURIComponent(branchName)) // URL'den gelen adı decode et
+    .single();
+
+  if (error || !data) {
+    return null;
+  }
+  return data.id;
+}
+
 // GET: Belirli bir şubenin finansal özetlerini getirir.
-export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id: branchId } = await params;
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) { // Parametre adı 'id' (dosya yolundaki gibi) olmalı
+  const { id: branchNameFromUrl } = await params; // branchNameFromUrl şube adını içerir
+  const branchId = await getBranchIdFromName(branchNameFromUrl);
+
+  if (!branchId) {
+    return NextResponse.json({ error: `'${decodeURIComponent(branchNameFromUrl)}' adlı şube bulunamadı.` }, { status: 404 });
+  }
   
   const { data, error } = await createClient()
     .from("branch_financials")
@@ -19,8 +39,14 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
 }
 
 // POST: Yeni bir finansal özet ekler.
-export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id: branchId } = await params;
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) { // Parametre adı 'id' (dosya yolundaki gibi) olmalı
+  const { id: branchNameFromUrl } = await params; // branchNameFromUrl şube adını içerir
+  const branchId = await getBranchIdFromName(branchNameFromUrl);
+
+  if (!branchId) {
+    return NextResponse.json({ error: `POST isteği için '${decodeURIComponent(branchNameFromUrl)}' adlı şube bulunamadı.` }, { status: 404 });
+  }
+
   const body = await request.json();
   // Beklenen alanlar: expenses, earnings, summary, date
   const { expenses, earnings, summary, date } = body;
@@ -29,7 +55,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     .from("branch_financials")
     .insert([
       {
-        branch_id: branchId,
+        branch_id: branchId, // Dinamik olarak alınan branchId'yi kullan
         expenses: parseFloat(expenses),
         earnings: parseFloat(earnings),
         summary,

--- a/components/navbar-top.tsx
+++ b/components/navbar-top.tsx
@@ -10,13 +10,13 @@ import { useMemo, useState } from 'react'; // useMemo import edildi
 import { UserStatus } from './user-status';
 
 export function TopNavbar() {
-	const { role, staffBranchId, loading: authLoading } = useAuth(); // Use the hook
+	const { role, staffBranchId, staffBranchName, loading: authLoading } = useAuth(); // staffBranchName eklendi
 	const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
 	// useEffect(() => {
 	//  // Optional: Log auth state changes for debugging
-	//  console.log('TopNavbar auth state:', { role, staffBranchId, authLoading });
-	// }, [role, staffBranchId, authLoading]);
+	//  console.log('TopNavbar auth state:', { role, staffBranchId, staffBranchName, authLoading });
+	// }, [role, staffBranchId, staffBranchName, authLoading]);
 
 	const baseNavLinks = useMemo(
 		() => [
@@ -42,13 +42,20 @@ export function TopNavbar() {
 	const dynamicNavLinks = useMemo(() => {
 		const links = [...baseNavLinks];
 		if (role === 'branch_staff') {
-			if (staffBranchId) {
+			if (staffBranchName) { // staffBranchId yerine staffBranchName kontrolü
 				links.unshift({
-					href: `/branch/${staffBranchId}`,
+					href: `/branch/${encodeURIComponent(staffBranchName)}`, // Şube adını kullan ve URL encode et
 					label: 'Şubem',
 					roles: ['branch_staff'],
 				});
-			} else {
+			} else if (staffBranchId && !staffBranchName && !authLoading) {
+				// ID var ama isim henüz yüklenmemişse veya bulunamamışsa (ve yükleme bitmişse)
+				links.unshift({
+					href: '/authorization-pending', // Ya da bir hata/bekleme sayfasına yönlendir
+					label: 'Şubem (Bilgi Bekleniyor)',
+					roles: ['branch_staff'],
+				});
+			} else { // Ne ID ne de isim varsa (veya authLoading ise, bu durum filteredLinks'te ele alınır)
 				links.unshift({
 					href: '/authorization-pending',
 					label: 'Şubem (Atanmadı)',
@@ -57,7 +64,7 @@ export function TopNavbar() {
 			}
 		}
 		return links;
-	}, [role, staffBranchId, baseNavLinks]);
+	}, [role, staffBranchId, staffBranchName, authLoading, baseNavLinks]); // staffBranchName ve authLoading eklendi
 
 	const filteredLinks = useMemo(() => {
 		if (authLoading) return []; // Yükleniyorsa hiç link gösterme


### PR DESCRIPTION
Bu değişiklik, kullanıcıların gördüğü URL'lerde şube ID'leri yerine şube adlarının gösterilmesini sağlar. Bu, URL'leri daha okunabilir ve kullanıcı dostu hale getirir.

Değişiklikler şunları içerir:
- Sayfa bileşenleri (branch-financials ve branch) artık URL'den şube adını parametre olarak alıyor.
- API rotası (`/api/branch/[id]`) artık şube adını parametre olarak kabul ediyor.
- Şube adından şube kimliğini (UUID) almak için ilgili yerlerde veritabanı sorguları eklendi.
- `useAuth` kancası, personelin atandığı şubenin adını da sağlayacak şekilde güncellendi.
- Navigasyon bağlantıları (navbar, admin şube listesi) artık şube adlarını kullanarak URL oluşturuyor.
- Dosya yolları fiziksel olarak değiştirilemediği için (araç sınırlaması), kod mevcut dosya yolu parametre adlarıyla (örn. `[branchId]`) çalışacak şekilde ayarlandı, ancak bu parametreler URL'den şube adını taşıyor.